### PR TITLE
ReleaseCiがこける

### DIFF
--- a/.github/workflows/deploygate-release.yml
+++ b/.github/workflows/deploygate-release.yml
@@ -35,9 +35,10 @@ jobs:
           touch release.jks
           echo "${{ secrets.RELEASE_JKS }}" | base64 -d >> release.jks
       - name: create google-services.json
+        working-directory: app/src/release
         run:
-          touch ./app/src/release/google-services.json
-          echo "${{ secrets.RELEASE_SERVICE_JSON }}" | base64 -d >> ./app/src/release/google-services.json
+          touch google-services.json
+          echo "${{ secrets.RELEASE_SERVICE_JSON }}" | base64 -d >> google-services.json
       - name: build release apk
         run:
           ./gradlew assembleRelease --no-daemon


### PR DESCRIPTION
## 概要

- release時に使用するCIの修正

## 変更点

- touchがファイル名がながすぎてこけていたのでworkdirの設定