### PR TITLE
Version up/ksp 2.0.21 1.0.25 to 2.1.0 1.0.29

### DIFF
--- a/app/src/main/java/com/snowdango/sumire/SumireApp.kt
+++ b/app/src/main/java/com/snowdango/sumire/SumireApp.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.snowdango.presenter.history.historyKoinModule
 import com.snowdango.sumire.infla.EventSharedFlow
 import com.snowdango.sumire.infla.PlayingSongSharedFlow

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ versionCode = "1"
 versionName = "0.0.1"
 
 agp = "8.7.3"
-ksp = "2.0.21-1.0.25"
+ksp = "2.0.21-1.0.28"
 kotlin = "2.0.21"
 coreKtx = "1.13.1"
 splashscreen = "1.0.1"

--- a/infla/build.gradle.kts
+++ b/infla/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.google.services)
 }
 
 android {
@@ -40,6 +41,11 @@ dependencies {
     implementation(libs.kotlinx.datetime)
     implementation(libs.koin)
     implementation(libs.coroutine.core)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.analytics)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/infla/src/main/AndroidManifest.xml
+++ b/infla/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>

--- a/presenter/history/src/main/java/com/snowdango/presenter/history/KoinModule.kt
+++ b/presenter/history/src/main/java/com/snowdango/presenter/history/KoinModule.kt
@@ -1,6 +1,6 @@
 package com.snowdango.presenter.history
 
-import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
 

--- a/presenter/playing/src/main/java/com/snowdango/sumire/presenter/playing/KoinModule.kt
+++ b/presenter/playing/src/main/java/com/snowdango/sumire/presenter/playing/KoinModule.kt
@@ -1,9 +1,9 @@
 package com.snowdango.sumire.presenter.playing
 
-import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
 
 val playingKoinModule = module {
-    viewModel { PlayingViewModel(get(),get()) }
+    viewModel { PlayingViewModel(get(), get()) }
 }


### PR DESCRIPTION
## 概要

- ksp version up 2.0.21 1.0.25 to 2.1.0 1.0.29

## 変更点

- kspのversion up
- inflaモジュールのgradleにimplementationを追加
- koinのviewModelのdslを変更