### PR TITLE
build: bump Java/Kotlin toolchain to 21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ local.properties
 siging.properties
 app/src/debug/google-services.json
 app/src/release/google-services.json
+check_elf_alignment.sh
+debug.jks
+release.jks

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,11 +63,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
     buildFeatures {
         compose = true

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -26,11 +26,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
 }
 

--- a/infla/build.gradle.kts
+++ b/infla/build.gradle.kts
@@ -25,11 +25,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
 }
 

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -24,11 +24,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
 }
 

--- a/presenter/history/build.gradle.kts
+++ b/presenter/history/build.gradle.kts
@@ -29,11 +29,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
 }
 

--- a/presenter/playing/build.gradle.kts
+++ b/presenter/playing/build.gradle.kts
@@ -26,11 +26,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
 }
 

--- a/presenter/settings/build.gradle.kts
+++ b/presenter/settings/build.gradle.kts
@@ -35,11 +35,11 @@ android {
         buildConfig = true
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
 }
 

--- a/presenter/widget/build.gradle.kts
+++ b/presenter/widget/build.gradle.kts
@@ -25,11 +25,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
     buildFeatures {
         compose = true

--- a/repository/build.gradle.kts
+++ b/repository/build.gradle.kts
@@ -26,11 +26,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
 }
 

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -29,11 +29,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
     buildFeatures {
         compose = true

--- a/ui/src/main/java/com/snowdango/sumire/ui/component/CircleSongArtwork.kt
+++ b/ui/src/main/java/com/snowdango/sumire/ui/component/CircleSongArtwork.kt
@@ -18,6 +18,7 @@ import androidx.core.graphics.drawable.toBitmap
 import com.snowdango.sumire.ui.R
 import com.snowdango.sumire.ui.UTIL_GROUP
 import com.snowdango.sumire.ui.theme.SumireTheme
+import androidx.compose.ui.platform.LocalResources
 
 @Composable
 fun CircleSongArtwork(
@@ -52,7 +53,7 @@ fun PreviewCircleSongArtwork() {
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(1f),
-            bitmap = LocalContext.current.resources.getDrawable(R.drawable.apple_music).toBitmap(),
+            bitmap = LocalResources.current.getDrawable(R.drawable.apple_music).toBitmap(),
         )
     }
 }

--- a/usecase/build.gradle.kts
+++ b/usecase/build.gradle.kts
@@ -24,11 +24,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
 }
 


### PR DESCRIPTION
## Summary
- 全Androidモジュールの `sourceCompatibility` / `targetCompatibility` を `JavaVersion.VERSION_21` に更新
- 各モジュールの `jvmToolchain` を `21` に更新
- ついでに `.gitignore` に `check_elf_alignment.sh` / `debug.jks` / `release.jks` を追加
- `CircleSongArtwork` のプレビューで `LocalContext.current.resources` を `LocalResources.current` に置き換え

## Test plan
- [ ] `./gradlew assembleDebug` がローカルで通る
- [ ] CircleCIの `build-test` ワークフローがpass
- [ ] `./gradlew testDebugUnitTest` がpass