### PR TITLE
build: bump compileSdk from 35 to 36

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 minsdk = "33"
-compileSdk = "35"
+compileSdk = "36"
 versionCode = "3"
 versionName = "0.0.3"
 


### PR DESCRIPTION
## Summary
- Bump `compileSdk` from 35 to 36 in `gradle/libs.versions.toml`.
- Several pending Dependabot bumps fail `checkDebugAarMetadata` because the newer artifacts require `compileSdk >= 36`:
  - #311 `androidx.core:core(-ktx):1.18.0`
  - #309 `androidx.activity:activity-compose:1.13.0` (pulls `androidx.navigationevent:*:1.0.0`)
- `targetSdk` is intentionally not set in any module, so this change implicitly upgrades both `compileSdk` and the effective `targetSdk` to 36.

## Test plan
- [ ] CircleCI `build-test` workflow passes (`lint` → `build` → `unittest`).
- [ ] CircleCI `vrt-test` workflow passes (`screen-shot` → `vrt` → `result-comment`).
- [ ] After merge, rebase #309 and #311 onto develop and confirm their CI turns green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)