### PR TITLE
feat: enhance Spotify support and refactor playing song state

### DIFF
--- a/app/src/main/java/com/snowdango/sumire/service/SongListenerService.kt
+++ b/app/src/main/java/com/snowdango/sumire/service/SongListenerService.kt
@@ -6,6 +6,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.ComponentName
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
 import android.media.MediaMetadata
 import android.media.session.MediaController
@@ -16,6 +17,7 @@ import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport
 import com.snowdango.sumire.data.entity.MusicApp
 import com.snowdango.sumire.data.entity.playing.PlayingSongData
 import com.snowdango.sumire.data.entity.playing.SongData
@@ -76,7 +78,10 @@ class SongListenerService : NotificationListenerService() {
     override fun onNotificationPosted(sbn: StatusBarNotification?) {
         super.onNotificationPosted(sbn)
         sbn?.let {
-            if (it.packageName == MusicApp.APPLE_MUSIC.packageName) {
+            if (
+                it.packageName == MusicApp.APPLE_MUSIC.packageName
+                || it.packageName == MusicApp.SPOTIFY.packageName
+            ) {
                 syncMediaMetadata(it.packageName)
             }
         }
@@ -107,12 +112,16 @@ class SongListenerService : NotificationListenerService() {
                             songSharedFlow.changeSong(
                                 queueId = currentQueueId,
                                 playingSongData = if (metadata != null) {
-                                    createPlayingSongData(metadata, it)
+                                    createPlayingSongData(
+                                        metadata,
+                                        it,
+                                        MusicApp.entries.first { app -> app.packageName == packageName }
+                                    )
                                 } else {
                                     null
                                 },
                             )
-                            loggingMediaController(metadata, it)
+                            loggingMediaController(packageName, metadata, it)
                         } catch (_: Exception) {
                             Log.e("GetMetadata", "failed get metadata")
                         }
@@ -125,13 +134,14 @@ class SongListenerService : NotificationListenerService() {
     private fun createPlayingSongData(
         metadata: MediaMetadata,
         mediaController: MediaController,
+        musicApp: MusicApp,
     ): PlayingSongData {
         return PlayingSongData(
             SongData(
                 title = metadata.getString(MediaMetadata.METADATA_KEY_TITLE),
                 artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST),
                 album = metadata.getString(MediaMetadata.METADATA_KEY_ALBUM),
-                app = MusicApp.APPLE_MUSIC,
+                app = musicApp,
                 artwork = metadata.getBitmap(MediaMetadata.METADATA_KEY_ART)
                     ?: metadata.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART),
                 mediaId = metadata.getString(MediaMetadata.METADATA_KEY_MEDIA_ID),
@@ -141,7 +151,23 @@ class SongListenerService : NotificationListenerService() {
         )
     }
 
+    private fun loggingMediaNotification(
+        packageName: String,
+    ) {
+        getSystemService(MediaSessionManager::class.java)?.let { mediaSessionManager ->
+            val componentName =
+                ComponentName(this@SongListenerService, SongListenerService::class.java)
+            appScope.launch {
+                mediaSessionManager.getActiveSessions(componentName)
+                    .find { it.packageName == packageName }?.let {
+                        loggingMediaController(packageName, it.metadata,it)
+                    }
+            }
+        }
+    }
+
     private fun loggingMediaController(
+        packageName: String,
         metadata: MediaMetadata?,
         mediaController: MediaController?,
     ) {

--- a/data/src/main/java/com/snowdango/sumire/data/entity/MusicApp.kt
+++ b/data/src/main/java/com/snowdango/sumire/data/entity/MusicApp.kt
@@ -2,7 +2,7 @@ package com.snowdango.sumire.data.entity
 
 enum class MusicApp(val apiProvider: String, val packageName: String, val platform: String) {
     APPLE_MUSIC("itunes", "com.apple.android.music", "appleMusic"),
-    SPOTIFY("spotify", "", "spotify"),
+    SPOTIFY("spotify", "com.spotify.music", "spotify"),
     YOUTUBE("youtube", "", "youtubeMusic"),
     GOOGLE("google", "", "google"),
     PANDORA("pandora", "", "pandora"),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ compileSdk = "36"
 versionCode = "3"
 versionName = "0.0.3"
 
-agp = "9.2.1"
+agp = "9.0.0"
 ksp = "2.3.4"
 kotlin = "2.3.20"
 coreKtx = "1.18.0"

--- a/infla/src/main/java/com/snowdango/sumire/infla/PlayingSongSharedFlow.kt
+++ b/infla/src/main/java/com/snowdango/sumire/infla/PlayingSongSharedFlow.kt
@@ -16,11 +16,10 @@ class PlayingSongSharedFlow : KoinComponent {
     private val eventSharedFlow: EventSharedFlow by inject()
     private val saveModel: SaveModel by inject()
 
+    @Volatile
     private var playingSong: Pair<Long, PlayingSongData>? = null
-        set(value) {
-            field = value
-            listener?.invoke(value?.second)
-        }
+
+    @Volatile
     var listener: ((playingSong: PlayingSongData?) -> Unit)? = null
     private var isWaitingTime: Boolean = false
     private val playingSongMutex = Mutex()
@@ -30,7 +29,9 @@ class PlayingSongSharedFlow : KoinComponent {
     suspend fun changeSong(queueId: Long?, playingSongData: PlayingSongData?) {
         withContext(Dispatchers.IO) {
             var type: PlayingSongChangeType = PlayingSongChangeType.NONE
-            playingSongMutex.withLock(playingSongData) {
+            var notifyListener = false
+            var listenerValue: PlayingSongData? = null
+            playingSongMutex.withLock {
                 val currentQueueId = playingSong?.first
                 if (currentQueueId != queueId) {
                     // change playingSong
@@ -39,6 +40,8 @@ class PlayingSongSharedFlow : KoinComponent {
                     } else {
                         null
                     }
+                    notifyListener = true
+                    listenerValue = playingSong?.second
                     type = if (queueId != null && playingSongData != null) {
                         if (playingSong?.second?.songData?.artwork == null) {
                             PlayingSongChangeType.CHANGE
@@ -59,6 +62,8 @@ class PlayingSongSharedFlow : KoinComponent {
                         } else {
                             null
                         }
+                        notifyListener = true
+                        listenerValue = playingSong?.second
                         type = PlayingSongChangeType.CHANGE_ACTIVE
                     } else if (
                         playingSong?.second?.songData?.artwork == null &&
@@ -73,9 +78,14 @@ class PlayingSongSharedFlow : KoinComponent {
                         } else {
                             null
                         }
+                        notifyListener = true
+                        listenerValue = playingSong?.second
                         type = PlayingSongChangeType.DATA_COMPLETE
                     }
                 }
+            }
+            if (notifyListener) {
+                listener?.invoke(listenerValue)
             }
             if (type != PlayingSongChangeType.NONE) {
                 changedPlayingSong(
@@ -96,7 +106,7 @@ class PlayingSongSharedFlow : KoinComponent {
         val current = playingSong
         if (type != PlayingSongChangeType.CHANGE_ACTIVE && type != PlayingSongChangeType.NONE) {
             var afterCheckType = AfterCheckType.NONE
-            isWaitingMutex.withLock(isWaitingTime) {
+            isWaitingMutex.withLock {
                 when (type) {
                     PlayingSongChangeType.CHANGE -> {
                         isWaitingTime = true
@@ -127,7 +137,7 @@ class PlayingSongSharedFlow : KoinComponent {
             delay(10_000)
             val curernt = playingSong
             withContext(Dispatchers.IO) {
-                isWaitingMutex.withLock(isWaitingTime) {
+                isWaitingMutex.withLock {
                     if (isWaitingTime) {
                         curernt?.let {
                             if (it.first == queueId) {

--- a/infla/src/main/java/com/snowdango/sumire/infla/PlayingSongSharedFlow.kt
+++ b/infla/src/main/java/com/snowdango/sumire/infla/PlayingSongSharedFlow.kt
@@ -17,173 +17,176 @@ class PlayingSongSharedFlow : KoinComponent {
     private val saveModel: SaveModel by inject()
 
     @Volatile
-    private var playingSong: Pair<Long, PlayingSongData>? = null
+    private var playingSong: PlayingState? = null
 
     @Volatile
     var listener: ((playingSong: PlayingSongData?) -> Unit)? = null
+
     private var isWaitingTime: Boolean = false
     private val playingSongMutex = Mutex()
     private val isWaitingMutex = Mutex()
 
-    @Suppress("CyclomaticComplexMethod")
     suspend fun changeSong(queueId: Long?, playingSongData: PlayingSongData?) {
         withContext(Dispatchers.IO) {
-            var type: PlayingSongChangeType = PlayingSongChangeType.NONE
-            var notifyListener = false
-            var listenerValue: PlayingSongData? = null
-            playingSongMutex.withLock {
-                val currentQueueId = playingSong?.first
-                if (currentQueueId != queueId) {
-                    // change playingSong
-                    playingSong = if (queueId != null && playingSongData != null) {
-                        Pair(queueId, playingSongData)
-                    } else {
-                        null
-                    }
-                    notifyListener = true
-                    listenerValue = playingSong?.second
-                    type = if (queueId != null && playingSongData != null) {
-                        if (playingSong?.second?.songData?.artwork == null) {
-                            PlayingSongChangeType.CHANGE
-                        } else {
-                            PlayingSongChangeType.DATA_COMPLETE
-                        }
-                    } else {
-                        PlayingSongChangeType.NONE
-                    }
-                } else if (playingSong != null && playingSongData != null) {
-                    if (playingSong?.second?.isActive != playingSongData.isActive) {
-                        // 　update isActive
-                        playingSong = if (queueId != null) {
-                            Pair(
-                                queueId,
-                                playingSongData.copy(playTime = playingSong!!.second.playTime),
-                            )
-                        } else {
-                            null
-                        }
-                        notifyListener = true
-                        listenerValue = playingSong?.second
-                        type = PlayingSongChangeType.CHANGE_ACTIVE
-                    } else if (
-                        playingSong?.second?.songData?.artwork == null &&
-                        playingSongData.songData.artwork != null
-                    ) {
-                        // update artwork
-                        playingSong = if (queueId != null) {
-                            Pair(
-                                queueId,
-                                playingSongData.copy(playTime = playingSong!!.second.playTime),
-                            )
-                        } else {
-                            null
-                        }
-                        notifyListener = true
-                        listenerValue = playingSong?.second
-                        type = PlayingSongChangeType.DATA_COMPLETE
-                    }
-                }
+            val result = updateState(queueId, playingSongData)
+            if (result.notifyListener) {
+                listener?.invoke(result.notifyValue)
             }
-            if (notifyListener) {
-                listener?.invoke(listenerValue)
-            }
-            if (type != PlayingSongChangeType.NONE) {
-                changedPlayingSong(
-                    type,
-                    queueId,
-                )
+            if (result.type != PlayingSongChangeType.NONE) {
+                handleStateChange(result.type, queueId)
             }
         }
     }
 
-    private suspend fun changedPlayingSong(
+    fun getCurrentPlayingSong(): PlayingSongData? = playingSong?.data
+
+    private suspend fun updateState(
+        queueId: Long?,
+        playingSongData: PlayingSongData?,
+    ): UpdateResult = playingSongMutex.withLock {
+        val current = playingSong
+        when {
+            current?.queueId != queueId ->
+                updateOnQueueChange(queueId, playingSongData)
+            current != null && queueId != null && playingSongData != null ->
+                updateOnSameQueue(current, queueId, playingSongData)
+            else ->
+                UpdateResult.NONE
+        }
+    }
+
+    private fun updateOnQueueChange(
+        queueId: Long?,
+        playingSongData: PlayingSongData?,
+    ): UpdateResult {
+        playingSong = if (queueId != null && playingSongData != null) {
+            PlayingState(queueId, playingSongData)
+        } else {
+            null
+        }
+        val type = when {
+            queueId == null || playingSongData == null -> PlayingSongChangeType.NONE
+            playingSongData.songData.artwork == null -> PlayingSongChangeType.CHANGE
+            else -> PlayingSongChangeType.DATA_COMPLETE
+        }
+        return UpdateResult(
+            type = type,
+            notifyListener = true,
+            notifyValue = playingSong?.data,
+        )
+    }
+
+    private fun updateOnSameQueue(
+        current: PlayingState,
+        queueId: Long,
+        playingSongData: PlayingSongData,
+    ): UpdateResult {
+        val updatedType = when {
+            current.data.isActive != playingSongData.isActive ->
+                PlayingSongChangeType.CHANGE_ACTIVE
+            current.data.songData.artwork == null && playingSongData.songData.artwork != null ->
+                PlayingSongChangeType.DATA_COMPLETE
+            else ->
+                return UpdateResult.NONE
+        }
+        playingSong = PlayingState(
+            queueId,
+            playingSongData.copy(playTime = current.data.playTime),
+        )
+        return UpdateResult(
+            type = updatedType,
+            notifyListener = true,
+            notifyValue = playingSong?.data,
+        )
+    }
+
+    private suspend fun handleStateChange(
         type: PlayingSongChangeType,
         queueId: Long?,
     ) {
-        eventSharedFlow.postEvent(
-            EventSharedFlow.SharedEvent.ChangeCurrentSong,
-        )
+        eventSharedFlow.postEvent(EventSharedFlow.SharedEvent.ChangeCurrentSong)
+        if (type == PlayingSongChangeType.CHANGE_ACTIVE) return
+
         val current = playingSong
-        if (type != PlayingSongChangeType.CHANGE_ACTIVE && type != PlayingSongChangeType.NONE) {
-            var afterCheckType = AfterCheckType.NONE
-            isWaitingMutex.withLock {
-                when (type) {
-                    PlayingSongChangeType.CHANGE -> {
-                        isWaitingTime = true
-                        afterCheckType = AfterCheckType.WAIT
-                    }
-
-                    PlayingSongChangeType.DATA_COMPLETE -> {
-                        isWaitingTime = false
-                        afterCheckType = AfterCheckType.COMPLETE
-                    }
-
-                    else -> {}
-                }
-            }
-            when (afterCheckType) {
-                AfterCheckType.WAIT -> waitMetadata(queueId)
-                AfterCheckType.COMPLETE -> current?.let { metaDataComplete(it.second) }
-                AfterCheckType.NONE -> {}
-            }
+        when (updateWaitingState(type)) {
+            AfterCheckType.WAIT -> waitMetadata(queueId)
+            AfterCheckType.COMPLETE -> current?.let { metaDataComplete(it.data) }
+            AfterCheckType.NONE -> {}
         }
     }
 
-    @Suppress("MagicNumber")
+    private suspend fun updateWaitingState(type: PlayingSongChangeType): AfterCheckType =
+        isWaitingMutex.withLock {
+            when (type) {
+                PlayingSongChangeType.CHANGE -> {
+                    isWaitingTime = true
+                    AfterCheckType.WAIT
+                }
+                PlayingSongChangeType.DATA_COMPLETE -> {
+                    isWaitingTime = false
+                    AfterCheckType.COMPLETE
+                }
+                else -> AfterCheckType.NONE
+            }
+        }
+
     private suspend fun waitMetadata(queueId: Long?) {
         if (queueId == null) return
-        var isComplete = false
-        withContext(Dispatchers.Default) {
-            delay(10_000)
-            val curernt = playingSong
-            withContext(Dispatchers.IO) {
-                isWaitingMutex.withLock {
-                    if (isWaitingTime) {
-                        curernt?.let {
-                            if (it.first == queueId) {
-                                isWaitingTime = false
-                                isComplete = true
-                            }
-                        }
-                    }
-                }
+        delay(METADATA_WAIT_TIMEOUT_MS)
+        val current = playingSong
+        val isComplete = isWaitingMutex.withLock {
+            if (isWaitingTime && current?.queueId == queueId) {
+                isWaitingTime = false
+                true
+            } else {
+                false
             }
-            if (isComplete) {
-                curernt?.let {
-                    metaDataComplete(it.second)
-                }
-            }
+        }
+        if (isComplete) {
+            current?.let { metaDataComplete(it.data) }
         }
     }
 
     private suspend fun metaDataComplete(playingSongData: PlayingSongData) {
         withContext(Dispatchers.Default) {
             Log.d(
-                "CurrentPlayingSong",
-                "DataComplete \nhasArtwork = ${playingSong?.second?.songData?.artwork != null}",
+                LOG_TAG,
+                "DataComplete \nhasArtwork = ${playingSong?.data?.songData?.artwork != null}",
             )
             saveModel.saveSong(playingSongData)
         }
     }
 
-    fun getCurrentPlayingSong(): PlayingSongData? {
-        return playingSong?.second
+    private data class PlayingState(
+        val queueId: Long,
+        val data: PlayingSongData,
+    )
+
+    private data class UpdateResult(
+        val type: PlayingSongChangeType,
+        val notifyListener: Boolean,
+        val notifyValue: PlayingSongData?,
+    ) {
+        companion object {
+            val NONE = UpdateResult(PlayingSongChangeType.NONE, false, null)
+        }
     }
 
-    enum class PlayingSongChangeType {
+    private enum class PlayingSongChangeType {
         DATA_COMPLETE,
         CHANGE,
         CHANGE_ACTIVE,
         NONE,
     }
 
-    enum class AfterCheckType {
+    private enum class AfterCheckType {
         COMPLETE,
         WAIT,
         NONE,
     }
 
-    interface ChangeListener {
-        fun onChanged()
+    companion object {
+        private const val LOG_TAG = "CurrentPlayingSong"
+        private const val METADATA_WAIT_TIMEOUT_MS = 10_000L
     }
 }


### PR DESCRIPTION
## Summary
- Spotifyを再生中アプリの対象に追加し、`MusicApp` を動的に判定するように修正
- `PlayingSongSharedFlow` のスレッドセーフティと可読性を改善するリファクタリング
- AGP を 9.2.1 から 9.0.0 にダウングレード

## Changes

### Spotify support
- `SongListenerService.onNotificationPosted` で Spotify のパッケージ名も処理対象に追加
- `createPlayingSongData` の `MusicApp` をハードコード（`APPLE_MUSIC`）から `packageName` を元に動的解決へ変更
- `loggingMediaController` / `loggingMediaNotification` に `packageName` を伝搬

### `PlayingSongSharedFlow` refactor
- `Mutex.withLock(owner)` の誤用を全箇所修正（`IllegalStateException` リスクを解消）
- ロック中に発火していた `listener?.invoke()` をロック外で呼ぶように変更（デッドロック予防）
- `playingSong` / `listener` に `@Volatile` を付与してマルチスレッド可視性を保証
- `Pair<Long, PlayingSongData>` を `PlayingState` data class に置き換え可読性向上
- `changeSong` を `updateState` / `updateOnQueueChange` / `updateOnSameQueue` / `handleStateChange` / `updateWaitingState` に分割
- 未使用の `ChangeListener` インターフェースを削除
- 内部型（`PlayingSongChangeType`, `AfterCheckType`, `PlayingState`, `UpdateResult`）を `private` 化
- マジックナンバー `10_000` を `METADATA_WAIT_TIMEOUT_MS` 定数化
- `@Suppress("CyclomaticComplexMethod")` / `@Suppress("MagicNumber")` を不要にする形で除去

### Build
- AGP 9.2.1 → 9.0.0 にダウングレード

## Test plan
- [ ] Spotify 再生時に曲情報が正しく検知・保存されること
- [ ] Apple Music 再生時に従来通り動作すること
- [ ] 曲切替時に Widget が更新されること
- [ ] 高頻度な曲切替でもリスナーコールバックがデッドロックしないこと
- [ ] `getCurrentPlayingSong()` がバックグラウンドスレッドから最新値を返すこと
- [ ] AGP 9.0.0 でビルドが成功すること